### PR TITLE
ci: deploy to github pages action

### DIFF
--- a/.github/workflows/deploy-gh.yml
+++ b/.github/workflows/deploy-gh.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build astro site
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install and build site
+        uses: withastro/action@v3
+        with:
+          node-version: 24
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,7 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: "https://josetorronteras.es",
+});


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate deployment to GitHub Pages and updates the Astro configuration to specify the site's URL. These changes streamline the deployment process and ensure the site is correctly configured for production.

### GitHub Actions Workflow for Deployment:
* Added a new workflow in `.github/workflows/deploy-gh.yml` to automate deployment to GitHub Pages. The workflow includes steps to build the Astro site and deploy it, triggered on pushes to the `main` branch or manually via `workflow_dispatch`.

### Astro Configuration Update:
* Updated `astro.config.mjs` to include the `site` property, specifying the production URL (`https://josetorronteras.es`) for the Astro site. This ensures proper configuration for features like RSS generation and canonical URLs.