### PR TITLE
deps: add dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  # Enable version updates for github-actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+      - ci
+      - auto
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+      - docker
+      - auto
+    groups:
+      all-docker:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+      - frontend
+      - auto
+    groups:
+      all-npm:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This pull request introduces a `.github/dependabot.yml` configuration file to automate dependency updates for GitHub Actions, Docker, and npm packages. The updates are scheduled weekly and include custom grouping, labeling, and commit message prefixes.

### Dependabot configuration added:

* **GitHub Actions**: Configured to update dependencies weekly on Sundays at 22:00. Updates are grouped under `all-actions` and labeled with `dependencies`, `ci`, and `auto`. Patch updates are ignored.
* **Docker**: Configured to update dependencies weekly on Sundays at 22:00. Updates are grouped under `all-docker` and labeled with `dependencies`, `docker`, and `auto`. Patch updates are ignored.
* **npm**: Configured to update dependencies weekly on Sundays at 22:00 with an "increase" versioning strategy. Updates are grouped under `all-npm` and labeled with `dependencies`, `frontend`, and `auto`. Patch updates are ignored.