### PR TITLE
ci: remove arm64 image build

### DIFF
--- a/.github/workflows/deploy-docker-ghcr.yml
+++ b/.github/workflows/deploy-docker-ghcr.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy-docker-ghcr.yml` file to simplify the platform specification for Docker builds in GitHub Actions.

Workflow simplification:

* `jobs:` in `.github/workflows/deploy-docker-ghcr.yml`: Updated the `platforms` field to always use `linux/amd64`, removing the conditional logic that previously determined the platforms based on the event type.