### PR TITLE
ci: disable clone content repository for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           fail-on-cache-miss: true
       - name: Clone private content repository
+        if: github.event.pull_request.user.login != 'app/dependabot' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v5
         with:
           repository: josetorronteras/josetorronteras.es-content


### PR DESCRIPTION
## Description:
Disables the clone content repository step for dependabot in the CI workflow.

## What's changed:
 - `.github/workflows/ci.yml`: Disabled clone step for dependabot