### PR TITLE
chore: remove lychee link checker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,5 +44,4 @@ LICENSE
 .vscode/
 
 # other configuration files
-.lycheeignore
 .prettierrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,3 @@ jobs:
         run: npm run check
       - name: Build site
         run: npm run build
-      - name: Add .lycheeignore
-        run: cp .lycheeignore ./dist/.lycheeignore
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
-        with:
-          args: --verbose --no-progress --root-dir '.' './**/*.html'
-          fail: true
-          failIfEmpty: false
-          workingDirectory: './dist'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,0 @@
-# Ingore URLs
-https://linkedin.com/in/josetorronteras
-https://www.alten.es/
-https://josetorronteras.es/404/


### PR DESCRIPTION
## Description:
Remove lychee link checker from project

## What's changed:
 - `.lycheeignore`: Deleted
 - Remove the CI steps (`Add .lycheeignore` and `Link Checker`)
 - Remove the reference to `.lycheeignore` in `.dockerignore`

## Summary by CodeRabbit

* **Chores**
  * Removed link-checking step from continuous integration workflow.
  * Cleaned up related configuration files and Docker build exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->