### PR TITLE
chore: change dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-      day: 'sunday'
       time: '22:00'
     commit-message:
       prefix: 'deps'
@@ -26,7 +25,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-      day: 'sunday'
       time: '22:00'
     commit-message:
       prefix: 'deps'
@@ -47,7 +45,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-      day: 'sunday'
       time: '22:00'
     versioning-strategy: 'increase'
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'sunday'
       time: '22:00'
     commit-message:
@@ -25,7 +25,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'sunday'
       time: '22:00'
     commit-message:
@@ -46,7 +46,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'sunday'
       time: '22:00'
     versioning-strategy: 'increase'


### PR DESCRIPTION
## Summary

- Change the Dependabot interval from `weekly` to `monthly` across all three ecosystems (npm, GitHub Actions, Docker)
- Reduce the frequency of automated PRs without losing visibility into new releases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the dependency update schedule to monthly for GitHub Actions, Docker, and npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->